### PR TITLE
Changes for storing LicenseKey in secret manager

### DIFF
--- a/firehose-template.yaml
+++ b/firehose-template.yaml
@@ -34,6 +34,8 @@ Metadata:
         default: 'Enables CloudWatch logging for Logging Firehose stream'
       CommonAttributes:
         default: 'Common Attributes to be added to the log events'
+      StoreNRLicenseKeyInSecretManager:
+        default: 'Store New Relic License Key in AWS Secrets Manager'
 
 Parameters:
   LicenseKey:
@@ -84,13 +86,29 @@ Parameters:
     Type: String
     Description: "String representation of JSON array of objects of custom attributes to organize your logs and make it easier for you to search, filter, analyze, and parse your logs"
     Default: ""
+  StoreNRLicenseKeyInSecretManager:
+    Type: String
+    Description: Should we store the New Relic license key in AWS Secrets Manager. Defaults to true.
+    Default: "true"
+    AllowedValues:
+      - "true"
+      - "false" 
 
 
 Conditions:
   AddCloudwatchTrigger: !Not [ !Equals [!Ref LogGroupConfig , ""]]
   ShouldEnableCloudWatchLogging: !Equals [!Ref EnableCloudWatchLoggingForFirehose, "true"]
-# TODO : Add secret manager condition and support if needed.
+  ShouldCreateSecret: !Equals [ !Ref StoreNRLicenseKeyInSecretManager, "true" ]
+
 Resources:
+
+  NewRelicLogsLicenseKeySecret:
+    Type: 'AWS::SecretsManager::Secret'
+    Condition: ShouldCreateSecret
+    Properties:
+      Description: The New Relic license key, for sending telemetry
+      Name : !Join ['-', ['nr-license-key', !Select [4, !Split ['-', !Select [2, !Split ['/', !Ref AWS::StackId]]]]]]
+      SecretString: !Sub '{ "LicenseKey": "${LicenseKey}"}'
 
   NewRelicLogsS3FirehoseEventsBucket:
     Type: AWS::S3::Bucket
@@ -290,7 +308,10 @@ Resources:
         EndpointConfiguration:
           Name: New Relic
           Url: !FindInMap [NewRelicDatacenterMap, Datacenter, !Ref NewRelicRegion]
-          AccessKey: !Ref LicenseKey
+          AccessKey: !If 
+            - ShouldCreateSecret
+            - !Sub '{{resolve:secretsmanager:${NewRelicLogsLicenseKeySecret}:SecretString:LicenseKey}}'
+            - !Ref LicenseKey
         BufferingHints:
           IntervalInSeconds: 60
           SizeInMBs: 1


### PR DESCRIPTION
This PR will add a new parameter StoreNRLicenseKeyInSecretManager, where user can select if they want to save LicenseKey in secret manager or not. By default this param is true.

Testing:
1. Tested with StoreNRLicenseKeyInSecretManager as true and can see the licenseKey getting saved in secret manager, and it is getting used in firehose stream and logs are flowing in new relic.
2. Tested with StoreNRLicenseKeyInSecretManager as false and can see the licenseKey is not getting saved in secret manager, and getting used directly in firehose stream and logs are flowing in new relic.