### PR TITLE
firehose integration should support firehose

### DIFF
--- a/firehose-template.yaml
+++ b/firehose-template.yaml
@@ -108,7 +108,7 @@ Resources:
     Properties:
       Description: The New Relic license key, for sending telemetry
       Name : !Join ['-', ['nr-license-key', !Select [4, !Split ['-', !Select [2, !Split ['/', !Ref AWS::StackId]]]]]]
-      SecretString: !Sub '{ "LicenseKey": "${LicenseKey}"}'
+      SecretString: !Sub '{ "api_key": "${LicenseKey}"}'
 
   NewRelicLogsS3FirehoseEventsBucket:
     Type: AWS::S3::Bucket
@@ -241,6 +241,12 @@ Resources:
                       else:
                           common_attributes = []
 
+                      # Filter out AttributeNames that are needed for entity synthesis from common_attributes
+                      existing_attribute_names = {attr['AttributeName'] for attr in additional_attributes}
+                      common_attributes = [
+                          attr for attr in common_attributes if attr['AttributeName'] not in existing_attribute_names
+                      ]
+                      
                       common_attributes.extend(additional_attributes)
 
                       log_group_config_json = json.loads(event_data.get('LogGroupConfig', '[]').strip() or '[]')
@@ -308,10 +314,10 @@ Resources:
         EndpointConfiguration:
           Name: New Relic
           Url: !FindInMap [NewRelicDatacenterMap, Datacenter, !Ref NewRelicRegion]
-          AccessKey: !If 
-            - ShouldCreateSecret
-            - !Sub '{{resolve:secretsmanager:${NewRelicLogsLicenseKeySecret}:SecretString:LicenseKey}}'
-            - !Ref LicenseKey
+          AccessKey: !If [ShouldCreateSecret, !Ref "AWS::NoValue",!Ref LicenseKey]
+        SecretsManagerConfiguration:
+          Enabled: !If [ShouldCreateSecret, true, false] 
+          SecretARN: !If [ShouldCreateSecret, !Ref NewRelicLogsLicenseKeySecret, !Ref "AWS::NoValue"]
         BufferingHints:
           IntervalInSeconds: 60
           SizeInMBs: 1


### PR DESCRIPTION
This PR will handle following two scenarios:
1. If user is passing value of parameter StoreNRLicenseKeyInSecretManager as `true` , the LicenseKey will be stored in secret manager and will be used from there.
2. There are few parameters which we are using for entity synthesis, if user passes those value as key in common attribute, we will ignore the values passed by user and use those values which are needed for Entity Synthesis. 

Testing Done:
1. Select StoreNRLicenseKeyInSecretManager as `true` and see if the secret are getting saved in secret manager and then used from there, the logs should flow in new relic in this scenario.
2. Select StoreNRLicenseKeyInSecretManager as `false`, create stack, see the delivery stream, it should use API Key for authentication, check if logs are flowing in new relic.
3. Attribute related testing: Tested by passing attributes which are used for Entity Synthesis, these attributes are not getting overriden. 

Ref: 
1.https://docs.aws.amazon.com/firehose/latest/dev/secrets-manager-whats-secret.html
5.https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kinesisfirehose-deliverystream-secretsmanagerconfiguration.html
6.https://github.com/hashicorp/terraform-provider-aws/issues/38210