### PR TITLE
code changes to validate JSON input array

### DIFF
--- a/firehose-template.yaml
+++ b/firehose-template.yaml
@@ -222,7 +222,60 @@ Resources:
                       region = event_data['AWS_REGION']
                       account_id = event_data['AWS_ACCOUNT_ID']
                       awsRealm = event_data['AWS_REALM']
+                      common_attributes_str = event_data['CommonAttributes']
+                      isAttributesValid = True
+                      isLogGroupValid = True
+
+                      try:
+                          attributes = json.loads(common_attributes_str)
+                          if not isinstance(attributes, list):
+                              raise ValueError('CommonAttributes must be a JSON array')
+                          for attribute in attributes:
+                              if not isinstance(attribute, dict):
+                                  raise ValueError("Each element in CommonAttributes should be a JSON object.")
+                              if 'AttributeName' not in attribute or 'AttributeValue' not in attribute:
+                                  raise ValueError("Each element in CommonAttributes should have 'AttributeName' and 'AttributeValue' keys.")
+                              if not attribute['AttributeName'] or not attribute['AttributeValue']:
+                                  raise ValueError("Each element in CommonAttributes should have non-empty 'AttributeName' and 'AttributeValue' values.")
+
+                          response['UserInputCommonAttributesErrorMessages'] = 'No Errors Found in User Input for setting up custom attributes.' 
+                      except Exception as e:
+                          logger.error(f'CommonAttributes provided {common_attributes_str} is not a valid JSON, the error is:  {str(e)}')
+                          isAttributesValid = False
+                          response['UserInputCommonAttributesErrorMessages'] = (
+                              'Validation Failed for Input Provided. The CommonAttributes provided : {} is not a valid JSON. '
+                              'Please provide a valid JSON for CommonAttributes.'.format(common_attributes_str)
+                          )
+
+                      try:
+                          log_group_config = event_data['LogGroupConfig']
+                          log_group_config_json = json.loads(log_group_config)
+                          if not isinstance(log_group_config_json, list):
+                              raise ValueError('LogGroupConfig must be a JSON array')
+                          for log_group in log_group_config_json:
+                              if not isinstance(log_group, dict):
+                                  raise ValueError("Each element in LogGroupConfig should be a JSON object.")
+                              if 'LogGroupName' not in log_group:
+                                  raise ValueError("Each element in LogGroupConfig should have 'LogGroupName' key.")
+                              if not log_group['LogGroupName']:
+                                  raise ValueError("Each element in LogGroupConfig should have non-empty 'LogGroupName' value.")
+
+                          response['LogGroupErrorMessages'] = 'No Errors Found in User Input for Log Group'
+                      except Exception as e:
+                          logger.error(f'LogGroup provided {log_group_config} is not a valid JSON, the error is:  {str(e)}')
+                          isLogGroupValid = False
+                          response['LogGroupErrorMessages'] = (
+                              'Validation Failed for Input Provided. The LogGroup provided : {} is not a valid JSON. '
+                              'Please provide a valid JSON for LogGroup.'.format(log_group_config)
+                          )
                       
+                      if(not isAttributesValid or not isLogGroupValid):
+                          response['LogGroupArns'] = ''
+                          response['InvalidLogGroups'] = ''
+                          response['CommonAttributes']= []
+                          cfnresponse.send(event, context, cfnresponse.SUCCESS, response)
+                          return
+
                       # these parameter are needed for entity synthesis
                       additional_attributes = [
                          {"AttributeName": "aws.accountId", "AttributeValue": account_id},
@@ -233,8 +286,7 @@ Resources:
                          {"AttributeName": "aws.realm", "AttributeValue": awsRealm}
                       ]
 
-
-                      common_attributes_str = event_data['CommonAttributes']
+                      
                       # Convert the json to the correct json format
                       if common_attributes_str.strip():
                           common_attributes = json.loads(common_attributes_str)
@@ -273,9 +325,9 @@ Resources:
                       response['CommonAttributes'] = common_attributes
                       response['LogGroupArns'] = ','.join(log_group_arns)
                       response['InvalidLogGroups'] = ','.join(invalid_log_groups)
-                      response['ErrorMessages'] = "No Errors Found in User Input"
+                      response['LogGroupErrorMessages'] = "No Errors Found in User Input for Log Group"
                       if invalid_log_groups:
-                            response['ErrorMessages'] = (
+                            response['LogGroupErrorMessages'] = (
                               'Validation Failed for Input Provided. These Log Groups: [{}] do not exist in your account.'
                               'Please setup Cloudwatch to Data Firehose subscription manually for additional log groups including these failed ones to stream with the resource Logical ID: "LoggingFirehoseStreamToNewRelic".'
                               'While setting up the subscription manuually you can use the IAM role with resource Logical ID: "CloudWatchFirehoseRole" created by this deployment.'.format(','.join(invalid_log_groups))
@@ -353,6 +405,9 @@ Outputs:
   NewRelicLogsLoggingFirehoseStreamArn:
     Description: The ARN of the Logging DataFirehose Stream.
     Value: !GetAtt NewRelicLogsFirehoseStreamToNewRelic.Arn
-  NewRelicLogsUserInputErrors:
-    Description: Contains Details about Errors in User Input.
-    Value: !GetAtt NewRelicLogsResourceForUserInputParsing.ErrorMessages
+  NewRelicLogsUserInputLogGroupErrors:
+    Description: Contains Details about Errors in User Input for LogGroup.
+    Value: !GetAtt NewRelicLogsResourceForUserInputParsing.LogGroupErrorMessages
+  NewRelicLogsUserInputCommonAttributeErrors:
+    Description: Contains Details about Errors in User Input for setting up Common Attributes in lambda.
+    Value: !GetAtt NewRelicLogsResourceForUserInputParsing.UserInputCommonAttributesErrorMessages


### PR DESCRIPTION
This PR will validate all the JSON array's received as input parameter in the cloud formation stack. 
Following is list of validation being done:
1. The input should be a valid JSON array.
2. Each element of array also should be a valid JSON object.
3. Each element should only have required keys, example : AttributeName and AttributeValue in case of CommonAttribute Param.
4. The value of keys should not be empty, example : The value of keys AttributeName and AttributeValue in case of CommonAttribute Param should not be empty. However in case of LogGroupConfig only one key `LogGroupName` is mandatory.

Testing done:
Passed these values from stack to test all he valid scenarios:


[{"LogGroupName":"xyz-hrai-fifteen", "FilterPattern":"ERROR"}]
[{"LogGroupName":"xyz-hrai-fifteen", "":"ERROR"}]

[{"AttributeName": "name", "AttributeValue": "hrai"}, {"": "surName", "AttributeValue": "hrai-rai"}]
[{"AttributeName": "name", "AttributeValue": "hrai"}, {"AttributeName": "surName", "AttributeValue": "hrai-rai"}

