### PR TITLE
delete of stack should delete filters as well

### DIFF
--- a/firehose-cloudwatch-trigger-stack.yaml
+++ b/firehose-cloudwatch-trigger-stack.yaml
@@ -138,16 +138,20 @@ Resources:
                           )
 
                   elif request_type == 'Delete':
-                      for log_group in log_group_config:
-                          log_group_name = log_group['LogGroupName']
-                          if log_group_name in invalid_log_groups:
-                              logger.info(f'Log group {log_group_name} is invalid. Skipping...')
-                              continue
-                          
-                          response = log_client.delete_subscription_filter(
-                            logGroupName=log_group_name,
-                            filterName=filter_name
-                          )
+                      try:
+                          for log_group in log_group_config:
+                              log_group_name = log_group['LogGroupName']
+                              if log_group_name in invalid_log_groups:
+                                  logger.info(f'Log group {log_group_name} is invalid. Skipping...')
+                                  continue
+                              
+                              response = log_client.delete_subscription_filter(
+                                logGroupName=log_group_name,
+                                filterName=filter_name
+                              )
+                      except Exception as e:
+                          logger.error(f'Delete failed for the log group subscription filters with error: {str(e)}')
+                          cfnresponse.send(event, context, cfnresponse.SUCCESS, response)
           
                   cfnresponse.send(event, context, cfnresponse.SUCCESS, response)
               except Exception as e:

--- a/firehose-cloudwatch-trigger-stack.yaml
+++ b/firehose-cloudwatch-trigger-stack.yaml
@@ -118,7 +118,7 @@ Resources:
                   log_group_config = json.loads(log_group_config_str)
 
                   # Unique filter name for this stack using firehose ARN
-                  filter_name = f'LoggingFirehoseSubscription_{hashlib.sha256(firehose_arn.encode()).hexdigest()[:20]}'
+                  filter_name = f'NewRelicLogsFirehoseSubscription_{hashlib.sha256(firehose_arn.encode()).hexdigest()[:20]}'
 
                   if request_type in ['Create', 'Update']:                                                   
                       for log_group in log_group_config:                      

--- a/firehose-cloudwatch-trigger-stack.yaml
+++ b/firehose-cloudwatch-trigger-stack.yaml
@@ -48,6 +48,7 @@ Resources:
               - Effect: Allow
                 Action:
                   - logs:PutSubscriptionFilter
+                  - logs:DeleteSubscriptionFilter
                 Resource: !Ref LogGroupArns
               - Effect: Allow
                 Action:
@@ -97,6 +98,7 @@ Resources:
           import cfnresponse
           import logging
           import os
+          import hashlib
 
           logger = logging.getLogger()
           logger.setLevel(logging.INFO)
@@ -106,31 +108,45 @@ Resources:
           def lambda_handler(event, context):
               response = {}
               try:
-                  if event['RequestType'] == 'Create' or event['RequestType'] == 'Update':
-                      event_data = event['ResourceProperties']
-                      firehose_arn = event_data.get('LoggingFirehoseStreamArn', '')
-                      
-                      log_group_config_str = event_data.get('LogGroupConfig', [])
-                      invalid_log_groups = set(event_data.get('InvalidLogGroups', []))
-                      logger.info(f'Invalid Log Groups: {invalid_log_groups}')
-    
-                      # Parsing LogGroupConfig JSON array
-                      log_group_config = json.loads(log_group_config_str)
+                  event_data = event['ResourceProperties']
+                  request_type = event['RequestType']
+                  firehose_arn = event_data.get('LoggingFirehoseStreamArn', '')
+                  log_group_config_str = event_data.get('LogGroupConfig', [])
+                  invalid_log_groups = set(event_data.get('InvalidLogGroups', []))
+
+                  # Parsing LogGroupConfig JSON array
+                  log_group_config = json.loads(log_group_config_str)
+
+                  # Unique filter name for this stack using firehose ARN
+                  filter_name = f'LoggingFirehoseSubscription_{hashlib.sha256(firehose_arn.encode()).hexdigest()[:20]}'
+
+                  if request_type in ['Create', 'Update']:                                                   
                       for log_group in log_group_config:                      
                           log_group_name = log_group['LogGroupName']
                           if log_group_name in invalid_log_groups:
                               logger.info(f'Log group {log_group_name} is invalid. Skipping...')
                               continue
                           filter_pattern = log_group['FilterPattern'] if 'FilterPattern' in log_group else ''
-
                           cloudwatch_firehose_role_arn = os.environ['CloudWatchFirehoseRoleArn']
 
                           response = log_client.put_subscription_filter(
                             logGroupName=log_group_name,
                             roleArn=cloudwatch_firehose_role_arn,
-                            filterName='LoggingFirehoseSubscription',
+                            filterName=filter_name,
                             filterPattern=filter_pattern,
                             destinationArn=firehose_arn
+                          )
+
+                  elif request_type == 'Delete':
+                      for log_group in log_group_config:
+                          log_group_name = log_group['LogGroupName']
+                          if log_group_name in invalid_log_groups:
+                              logger.info(f'Log group {log_group_name} is invalid. Skipping...')
+                              continue
+                          
+                          response = log_client.delete_subscription_filter(
+                            logGroupName=log_group_name,
+                            filterName=filter_name
                           )
           
                   cfnresponse.send(event, context, cfnresponse.SUCCESS, response)


### PR DESCRIPTION
After this code changes:

On stack deletion, we will delete any subscription filter created on any log group created as part of this particular stack

Testing:

1. Create a stack with selecting log group name, see that a subscription filter is created. Delete the stack, the subscription filter should be deleted.
2. Take a log group with existing subscription filter already present. Create a cloud formation stack with this particular stack, see that second subscription filter get created. Now delete this stack, only the second subscription filter should be deleted. The subscription filter created prior to our stack creation should not get deleted.