### PR TITLE
E2E tests workflow configuration modification

### DIFF
--- a/.github/workflows/run-e2e-tests.yaml
+++ b/.github/workflows/run-e2e-tests.yaml
@@ -1,13 +1,13 @@
 name: E2E Test Workflow For Firehose
 
 on:
-  push:
-    branches:
-      - main
-      - develop
+  pull_request_review:
+    types:
+      - submitted
 
 jobs:
   deploy-and-test:
+    if: github.event.review.state == 'approved'
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -42,3 +42,11 @@ jobs:
           ./build_template.sh
           ./firehose_e2e_tests.sh ${{ matrix.test-case }}
 
+      - name: Send failure notification to Slack
+        if: always()
+        uses: ravsamhq/notify-slack-action@v1
+        with:
+          status: ${{ job.status }}
+          notify_when: 'failure'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/run-e2e-tests.yaml
+++ b/.github/workflows/run-e2e-tests.yaml
@@ -4,6 +4,8 @@ on:
   pull_request_review:
     types:
       - submitted
+  schedule:
+    - cron: '0 0 1 * *'
 
 jobs:
   deploy-and-test:


### PR DESCRIPTION
1. Tests will run only when any pr is approved
2. On tests failure, slack notification is sent to logging-integrations-channel