### PR TITLE
updated entity_synthesis_param.cfg file with version change and new line

### DIFF
--- a/.github/workflows/run-e2e-tests.yaml
+++ b/.github/workflows/run-e2e-tests.yaml
@@ -1,12 +1,15 @@
 name: E2E Test Workflow For Firehose
 
 on:
-  pull_request:
-    branches:
-      - develop
+  pull_request_review:
+    types:
+      - submitted
+  schedule:
+    - cron: '0 0 1 * *'
 
 jobs:
   deploy-and-test:
+    if: github.event.review.state == 'approved'
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -40,3 +43,12 @@ jobs:
           cd e2e_tests/
           ./build_template.sh
           ./firehose_e2e_tests.sh ${{ matrix.test-case }}
+
+      - name: Send failure notification to Slack
+        if: always()
+        uses: ravsamhq/notify-slack-action@v1
+        with:
+          status: ${{ job.status }}
+          notify_when: 'failure'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/run-e2e-tests.yaml
+++ b/.github/workflows/run-e2e-tests.yaml
@@ -1,15 +1,12 @@
 name: E2E Test Workflow For Firehose
 
 on:
-  pull_request_review:
-    types:
-      - submitted
-  schedule:
-    - cron: '0 0 1 * *'
+  pull_request:
+    branches:
+      - develop
 
 jobs:
   deploy-and-test:
-    if: github.event.review.state == 'approved'
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -43,12 +40,3 @@ jobs:
           cd e2e_tests/
           ./build_template.sh
           ./firehose_e2e_tests.sh ${{ matrix.test-case }}
-
-      - name: Send failure notification to Slack
-        if: always()
-        uses: ravsamhq/notify-slack-action@v1
-        with:
-          status: ${{ job.status }}
-          notify_when: 'failure'
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/e2e_tests/entity_synthesis_param.cfg
+++ b/e2e_tests/entity_synthesis_param.cfg
@@ -1,4 +1,4 @@
 # Entity synthesis Parameters , aws related params are dropped in pipeline.
 instrumentation_provider=aws
 instrumentation_name=firehose
-instrumentation_version=1.1.0
+instrumentation_version=1.0.0

--- a/e2e_tests/entity_synthesis_param.cfg
+++ b/e2e_tests/entity_synthesis_param.cfg
@@ -1,4 +1,4 @@
 # Entity synthesis Parameters , aws related params are dropped in pipeline.
 instrumentation_provider=aws
 instrumentation_name=firehose
-instrumentation_version=1.0.0
+instrumentation_version=1.1.0

--- a/version.yaml
+++ b/version.yaml
@@ -1,1 +1,1 @@
-instrumentation_version: "1.1.0"
+instrumentation_version: "1.0.0"


### PR DESCRIPTION
entity synthesis was failing in e2e tests because the last parameter in the config file was not read due to missing /n. Added version change and new line to e2e tests