### PR TITLE
[NR-475488] enable retention period for log groups

### DIFF
--- a/firehose-cloudwatch-trigger-stack.yaml
+++ b/firehose-cloudwatch-trigger-stack.yaml
@@ -165,7 +165,7 @@ Resources:
   NewRelicLogsCloudWatchFirehoseEventLambdaLogGroup:
     Type: AWS::Logs::LogGroup
     DeletionPolicy: Delete
-    DependsOn: NewRelicLogsCloudWatchFirehoseEventLambda
+    Condition: HasValidLogGroups
     Properties:
       RetentionInDays: 14
       LogGroupName: !Sub "/aws/lambda/${NewRelicLogsCloudWatchFirehoseEventLambda}"

--- a/firehose-cloudwatch-trigger-stack.yaml
+++ b/firehose-cloudwatch-trigger-stack.yaml
@@ -161,3 +161,11 @@ Resources:
       Role: !GetAtt NewRelicLogsCloudWatchFirehoseLambdaIAMRole.Arn
       Runtime: python3.12
       Timeout: 120
+
+  NewRelicLogsCloudWatchFirehoseEventLambdaLogGroup:
+    Type: AWS::Logs::LogGroup
+    DeletionPolicy: Delete
+    DependsOn: NewRelicLogsCloudWatchFirehoseEventLambda
+    Properties:
+      RetentionInDays: 14
+      LogGroupName: !Sub "/aws/lambda/${NewRelicLogsCloudWatchFirehoseEventLambda}"

--- a/firehose-template.yaml
+++ b/firehose-template.yaml
@@ -360,7 +360,6 @@ Resources:
   NewRelicLogsUserInputParserLambdaLogGroup:
     Type: AWS::Logs::LogGroup
     DeletionPolicy: Delete
-    DependsOn: NewRelicLogsUserInputParserLambda
     Properties:
       RetentionInDays: 14
       LogGroupName: !Sub "/aws/lambda/${NewRelicLogsUserInputParserLambda}"

--- a/firehose-template.yaml
+++ b/firehose-template.yaml
@@ -173,6 +173,7 @@ Resources:
   
   NewRelicLogsFirehoseErrorLogGroup:
     Type: AWS::Logs::LogGroup
+    DeletionPolicy: Delete
     Condition: ShouldEnableCloudWatchLogging
     Properties:
       LogGroupName: !Join ['/', ['/aws/datafirehose-newrelic/', !Ref 'AWS::StackName', 'FirehoseError']]
@@ -355,6 +356,14 @@ Resources:
       Role: !GetAtt NewRelicLogsUserInputParserLambdaIAMRole.Arn
       Timeout: 120
       MemorySize: 128
+
+  NewRelicLogsUserInputParserLambdaLogGroup:
+    Type: AWS::Logs::LogGroup
+    DeletionPolicy: Delete
+    DependsOn: NewRelicLogsUserInputParserLambda
+    Properties:
+      RetentionInDays: 14
+      LogGroupName: !Sub "/aws/lambda/${NewRelicLogsUserInputParserLambda}"
 
   NewRelicLogsResourceForUserInputParsing:
     Type: AWS::CloudFormation::CustomResource


### PR DESCRIPTION
Inline lambdas create log groups to post errors during cloud formation template deployment. 
1. Added retention period of 14 days. 
2. Created deletion policy so log groups get deleted when stack is deleted. 